### PR TITLE
Reenable Travis CI notifications

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,3 @@ install:
 script: make test
 
 services: redis
-
-notifications:
-    email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,3 +10,8 @@ install:
 script: make test
 
 services: redis
+
+notifications:
+    email:
+        on_success: change
+        on_failure: change


### PR DESCRIPTION
Now that everything is stable we can turn email notifications back on