### PR TITLE
Update to RQ 0.13 to handle Redis update

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 test:
-	py.test --flake8 --cov=rq_retry_scheduler --cov-config .coveragerc
+	py.test --cov=rq_retry_scheduler --cov-config .coveragerc
+	git ls-files '*.py' | xargs flake8
 
 coverage-html:
 	coverage html -d coverage_html

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # Development pip requirements
-rq
+rq>=0.13
 pytest>=3.0.2
 pytest-cov
 pytest-mock

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 # Development pip requirements
+flake8
 rq>=0.13
 pytest>=3.0.2
 pytest-cov
 pytest-mock
 pytest-env
-pytest-flake8
 coveralls
 pytz; python_version <= '2.7'

--- a/rq_retry_scheduler/__init__.py
+++ b/rq_retry_scheduler/__init__.py
@@ -1,3 +1,10 @@
 from .queue import Queue
 from .scheduler import Scheduler
 from .worker import Worker
+
+
+__all__ = [
+    'Queue',
+    'Scheduler',
+    'Worker',
+]

--- a/rq_retry_scheduler/cli/__init__.py
+++ b/rq_retry_scheduler/cli/__init__.py
@@ -1,1 +1,6 @@
 from .scheduler import main
+
+
+__all__ = [
+    'main',
+]

--- a/rq_retry_scheduler/cli/scheduler.py
+++ b/rq_retry_scheduler/cli/scheduler.py
@@ -6,7 +6,7 @@ import click
 from datetime import datetime
 from functools import partial
 import logging
-from redis import StrictRedis
+from redis import Redis
 from rq.cli import cli as rqcli
 from rq.cli import helpers
 from rq.utils import ColorizingStreamHandler
@@ -20,7 +20,7 @@ config_option = click.option('--config', '-c', envvar='RQ_CONFIG',
                              help='Module containing RQ settings.')
 
 
-def connect(url, config=None, connection_class=StrictRedis):
+def connect(url, config=None, connection_class=Redis):
     if url:
         return connection_class.from_url(url)
 

--- a/rq_retry_scheduler/queue.py
+++ b/rq_retry_scheduler/queue.py
@@ -20,8 +20,8 @@ class Queue(rq.Queue):
         logger.info('Queuing job {0:s} to run at {1:s}'.format(
             job.id, str(enqueue_dt)))
 
-        self.connection._zadd(
-            self.scheduler_jobs_key, util.to_unix(enqueue_dt), job.id)
+        self.connection.zadd(
+            self.scheduler_jobs_key, {job.id: util.to_unix(enqueue_dt)})
 
         job.meta['scheduled_for'] = enqueue_dt
 

--- a/rq_retry_scheduler/scheduler.py
+++ b/rq_retry_scheduler/scheduler.py
@@ -59,7 +59,7 @@ class Scheduler(object):
 
     def delay_job(self, job, time_delta):
         amount = int(time_delta.total_seconds())
-        self.connection.zincrby(self.scheduler_jobs_key, job.id, amount)
+        self.connection.zincrby(self.scheduler_jobs_key, amount, job.id)
 
     def should_repeat_job(self, job):
         max_runs = job.meta['max_runs']

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 
 setup(
     name='rq-retry-scheduler',
-    version='0.1.2',
+    version='0.2.0',
     url='https://github.com/mikemill/rq_retry_scheduler',
     description='RQ Retry and Scheduler',
     long_description=long_description(),
@@ -21,7 +21,7 @@ setup(
     author_email='mikemill@gmail.com',
     packages=find_packages(exclude=['*tests*']),
     license='MIT',
-    install_requires=['rq>=0.6.0'],
+    install_requires=['rq>=0.13'],
     zip_safe=False,
     platforms='any',
     entry_points={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 import pytest
-from redis import StrictRedis
+from redis import Redis
 
 from rq_retry_scheduler import Queue, Worker, Scheduler
 
@@ -9,7 +9,7 @@ from rq_retry_scheduler import Queue, Worker, Scheduler
 def redis_db_num():
     """Find an empty Redis database to use"""
     for dbnum in range(4, 17):
-        conn = StrictRedis(db=dbnum)
+        conn = Redis(db=dbnum)
         if len(conn.keys('*')) == 0:
             return dbnum
     assert False, "Couldn't find an empty Redis DB"
@@ -17,7 +17,7 @@ def redis_db_num():
 
 @pytest.yield_fixture
 def connection(redis_db_num):
-    conn = StrictRedis(db=redis_db_num)
+    conn = Redis(db=redis_db_num)
     try:
         yield conn
     finally:

--- a/tests/test_queue.py
+++ b/tests/test_queue.py
@@ -108,7 +108,7 @@ def test_enqueue_job_in(mock, queue, connection):
 
 
 def test_schedule_job(mock, queue, connection):
-    zadd = mock.patch.object(connection, '_zadd')
+    zadd = mock.patch.object(connection, 'zadd')
 
     job = Job.create(target_function, connection=connection)
 
@@ -117,7 +117,8 @@ def test_schedule_job(mock, queue, connection):
 
     queue.schedule_job(job, dt)
 
-    zadd.assert_called_with(queue.scheduler_jobs_key, util.to_unix(dt), job.id)
+    zadd.assert_called_with(
+        queue.scheduler_jobs_key, {job.id: util.to_unix(dt)})
     assert save.called
     assert job.meta.get('scheduled_for') == dt
 


### PR DESCRIPTION
Redis changed the way `zadd` was handled and `RQ` updated to handle that and removed `_zadd`.  So deal with the chain of updates.